### PR TITLE
Ported to iOS 6 in two different ways: precise and quick'n'dirty.

### DIFF
--- a/Classes/TOMSMorphingLabel.m
+++ b/Classes/TOMSMorphingLabel.m
@@ -6,6 +6,8 @@
 //  Copyright (c) 2014 TomKnig. All rights reserved.
 //
 
+#import <CoreText/CoreText.h>
+
 #import "TOMSMorphingLabel.h"
 
 #define kTOMSKernFactorAttributeName @"kTOMSKernFactorAttributeName"
@@ -303,7 +305,30 @@
             NSMutableDictionary *attributionStage = self.attributionStages[attributionIndex];
             CGFloat kernFactor = [attributionStage[kTOMSKernFactorAttributeName] floatValue];
             NSString *character = [aString substringWithRange:range];
-            CGSize characterSize = [character sizeWithAttributes:@{NSFontAttributeName: attributionStage[NSFontAttributeName]}];
+            CGSize characterSize = CGSizeZero;
+
+            if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+#ifdef PRECISE_FONT_METRICS
+    #define CFAutomatedReferenceCount(CFAnyTypeRef, typeRef, CFCreateOrCopyFunction) CFAnyTypeRef typeRef = ((__bridge CFAnyTypeRef)CFBridgingRelease(CFCreateOrCopyFunction))
+                @autoreleasepool {
+                    UIFont *font = attributionStage[NSFontAttributeName];
+                    CFAutomatedReferenceCount(CTFontRef, fontRef, CTFontCreateWithName((__bridge CFStringRef)font.fontName, font.pointSize, NULL));
+                    CFAutomatedReferenceCount(CFAttributedStringRef, attributed, CFAttributedStringCreate(NULL, (__bridge CFStringRef)character, (__bridge CFDictionaryRef)@{(id)kCTFontAttributeName : (__bridge id)fontRef}));
+                    CFAutomatedReferenceCount(CTFramesetterRef, framesetter, CTFramesetterCreateWithAttributedString(attributed));
+                    CFAutomatedReferenceCount(CGPathRef, path, CGPathCreateWithRect(CGRectInfinite, NULL));
+                    CFAutomatedReferenceCount(CTFrameRef, frame, CTFramesetterCreateFrame(framesetter, CFRangeMake(0, CFAttributedStringGetLength(attributed)), path, NULL));
+                    NSArray *lines = (id)CTFrameGetLines(frame);
+                    characterSize = CTLineGetBoundsWithOptions((__bridge CTLineRef)[lines firstObject], 0).size;
+                }
+    #undef CFAutomatedReferenceCount
+#else /* Quick and dirty font metrics */
+                characterSize = [character sizeWithFont:attributionStage[NSFontAttributeName]];
+#endif
+            }
+            else {
+                characterSize = [character sizeWithAttributes:@{NSFontAttributeName: attributionStage[NSFontAttributeName]}];
+            }
+
             attributionStage[NSKernAttributeName] = [NSNumber numberWithFloat:(-kernFactor * characterSize.width)];
             
             [attributedText setAttributes:attributionStage

--- a/TOMSMorphingLabel.podspec
+++ b/TOMSMorphingLabel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "TOMSMorphingLabel"
-  s.version          = "0.2.0"
+  s.version          = "0.2.1"
   s.summary          = "Configurable morphing transitions between text values of a label."
   s.homepage         = "https://github.com/TomKnig/TOMSMorphingLabel"
   s.license          = 'MIT'
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/TomKnig/TOMSMorphingLabel.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/TomKnig'
 
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '6.0'
   s.requires_arc = true
 
   s.source_files = 'Classes/*.{h,m}'


### PR DESCRIPTION
Hello! Ported your awesome component to iOS 6. The changes are actually very simple. Since the new iOS 7 APIs are wrapping existing CoreText functions, it was a matter of simulating what happens behind the curtains.

The precise method probably incurs in more overhead than the iOS 7 API it attempts to reproduce, but that's what the public APIs allow. The quick'n'dirty method is probably good enough anyway.

In any circumstance under the simulator the iOS 7 version runs much quicker than the iOS 6 one. That's not a limitation of the overhead: even the QnD version seems slow, and if the foundation guard is taken away and the CoreText method is run unconditionally, the iOS 7 animation speed is the same as before. So there's something weird with (simulated) iOS 6 that's probably not even worth tracking down.

Anyway, great job, and hope you like my contribution!
