### PR TITLE
Fixed text color-change glitch

### DIFF
--- a/Classes/TOMSMorphingLabel.m
+++ b/Classes/TOMSMorphingLabel.m
@@ -316,6 +316,7 @@
             attributionIndex = MIN(self.numberOfAttributionStages - 1, MAX(0, attributionIndex));
             
             NSMutableDictionary *attributionStage = self.attributionStages[attributionIndex];
+            attributionStage[NSForegroundColorAttributeName] = self.textColor;
             CGFloat kernFactor = [attributionStage[kTOMSKernFactorAttributeName] floatValue];
             NSString *character = [aString substringWithRange:range];
             CGSize characterSize = CGSizeZero;


### PR DESCRIPTION
If the text color of the label changes, the animated characters will stay the original color during animations.  During the attribution stage, the current color of the text is applied to the attributed text so that that the animated changes are the correct color.
