### PR TITLE
Respect global [UIView areAnimationsEnabled] state.

### DIFF
--- a/Classes/TOMSMorphingLabel.m
+++ b/Classes/TOMSMorphingLabel.m
@@ -156,9 +156,9 @@
 
 #pragma mark - Getters
 
-- (BOOL)isMorphingEnabled
+- (BOOL)shouldAnimateSettingText
 {
-    return _morphingEnabled && [UIView areAnimationsEnabled];
+    return self.isMorphingEnabled && [UIView areAnimationsEnabled];
 }
 
 - (CGFloat)easedValue:(CGFloat)p
@@ -263,7 +263,7 @@
 
 - (void)setText:(NSString*) text withCompletionBlock:(void (^)(void))block{
     _setTextCompletionBlock = block;
-    if (self.isMorphingEnabled) {
+    if ([self shouldAnimateSettingText]) {
         self.nextText = text ? text : @"";
         if (self.displayLinkDuration > 0) {
             [self beginMorphing];


### PR DESCRIPTION
Hi! I suppose `TOMSMorphingLabel` should also respect the global `areAnimationsEnabled` flag of the `UIView` class so that setting the text like this:

``` objc
[UIView performWithoutAnimation: ^{
     tomsLabel.text = @"new text";
}];
```

will actually set the text without animation as expected.

The same goes for the following:

``` objc
[UIView setAnimationsEnabled: NO];
tomsLabel.text = @"new text";
```

As per documentation for [`setAnimationsEnabled:`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIView_Class/#//apple_ref/occ/clm/UIView/setAnimationsEnabled:), if we disable animations, the currently running animation blocks will continue, but subsequent animation blocks will perform without animation. So checking the `[UIView areAnimationsEnabled]` state in the `isMorphingEnabled` getter seems reasonable enough - it won't affect the already started animations but will prevent new ones to start. 
