### PR TITLE
Invoke the completion block even if setting text without animations.

### DIFF
--- a/Classes/TOMSMorphingLabel.m
+++ b/Classes/TOMSMorphingLabel.m
@@ -265,6 +265,10 @@
         }
     } else {
         super.text = text;
+        if (_setTextCompletionBlock != nil) {
+            _setTextCompletionBlock();
+            _setTextCompletionBlock = nil;
+        }
     }
 }
 


### PR DESCRIPTION
Hi! I think the completion block of `setText:withCompletionBlock:` should be called regardless of whether we're setting the text with animations or not. 

When a method with completion block is called, it is kind of assumed that the block will be executed at some point. Otherwise we cannot really know whether it would be called or not without checking the `isMorphingEnabled` property. 
