### PR TITLE
Break the strong reference cycle between CADisplayLink and TOMSMorphingLabel.

### DIFF
--- a/Classes/TOMSMorphingLabel.m
+++ b/Classes/TOMSMorphingLabel.m
@@ -12,6 +12,18 @@
 
 #define kTOMSKernFactorAttributeName @"kTOMSKernFactorAttributeName"
 
+/** A helper class which is used to break the strong reference cycle
+ *  between CADisplayLink and TOMSMorphingLabel. Does nothing significant,
+ *  just forwards all messages to its morphingLabel property.
+ */
+@interface TOMSMorphingLabelWeakWrapper : NSObject
+@property (nonatomic, weak, readonly) TOMSMorphingLabel *morphingLabel;
+
+- (instancetype)initWithLabel:(TOMSMorphingLabel *)label;
+
+@end
+
+
 @interface TOMSMorphingLabel (){
     void (^_setTextCompletionBlock)(void);
 }
@@ -78,14 +90,18 @@
     _morphingEnabled = YES;
     self.animating = NO;
     
-    self.displayLink = [CADisplayLink displayLinkWithTarget:self
-                                                   selector:@selector(tickInitial)];
-    [self.displayLink addToRunLoop:[NSRunLoop currentRunLoop]
-                           forMode:NSRunLoopCommonModes];
+    [self setupDisplayLinkWithSelector:@selector(tickInitial)];
     
     self.animationDuration = 0.37;
     self.characterAnimationOffset = 0.25;
     self.characterShrinkFactor = 4;
+}
+
+
+- (void)dealloc
+{
+    [_displayLink invalidate];
+    _displayLink = nil;
 }
 
 #pragma mark - Setters
@@ -144,14 +160,25 @@
         self.displayLink.paused = YES;
         CFTimeInterval duration = self.displayLink.duration;
         
-        self.displayLink = [CADisplayLink displayLinkWithTarget:self
-                                                           selector:@selector(tickMorphing)];
-        [self.displayLink addToRunLoop:[NSRunLoop currentRunLoop]
-                               forMode:NSRunLoopCommonModes];
+        [self setupDisplayLinkWithSelector: @selector(tickMorphing)];
         self.displayLink.paused = YES;
         
         self.displayLinkDuration = duration;
     }
+}
+
+
+- (void)setupDisplayLinkWithSelector:(SEL)selector
+{
+    TOMSMorphingLabelWeakWrapper *displayLinkTarget = [[TOMSMorphingLabelWeakWrapper alloc] initWithLabel:self];
+    CADisplayLink *displayLink = [CADisplayLink displayLinkWithTarget:displayLinkTarget
+                                                             selector:selector];
+    
+    [displayLink addToRunLoop:[NSRunLoop currentRunLoop]
+                      forMode:NSRunLoopCommonModes];
+    
+    [self.displayLink invalidate];
+    self.displayLink = displayLink;
 }
 
 #pragma mark - Getters
@@ -431,3 +458,30 @@
 }
 
 @end
+
+
+@implementation TOMSMorphingLabelWeakWrapper
+
+- (instancetype)initWithLabel:(TOMSMorphingLabel *)label
+{
+    self = [super init];
+    
+    if (self) {
+        _morphingLabel = label;
+    }
+    
+    return self;
+}
+
+- (void)tickInitial
+{
+    [self.morphingLabel tickInitial];
+}
+
+- (void)tickMorphing
+{
+    [self.morphingLabel tickMorphing];
+}
+
+@end
+


### PR DESCRIPTION
Hi, I've implemented a simple solution to the retain cycle problem described in #12. Please tell if that works for you. 

`CADisplayLink` retains the object set as its target and `TOMSMorphingLabel` references the display link strongly. This gives a strong reference cycle and `TOMSMorphingLabel` is never deallocated. This PR adds a helper class named `TOMSMorphingLabelWeakWrapper` which holds a weak reference to the label and forwards necessary messages to it. This breaks the reference cycle and allows deallocating the label.

Note that if the weak wrapper's label reference gets nullified due to the label being deallocated, the display link would continue firing its events to the weak wrapper. So it is necessary to properly invalidate the display link in the `TOMSMorphingLabel`'s dealloc.
