### PR TITLE
Minor non-breaking interface changes

### DIFF
--- a/Classes/NSString+Morphing.h
+++ b/Classes/NSString+Morphing.h
@@ -8,9 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
-#define kTOMSDictionaryKeyMergedString @"mergedString"
-#define kTOMSDictionaryKeyAdditionRanges @"additionRanges"
-#define kTOMSDictionaryKeyDeletionRanges @"deletionRanges"
+extern NSString * const kTOMSDictionaryKeyMergedString;
+extern NSString * const kTOMSDictionaryKeyAdditionRanges;
+extern NSString * const kTOMSDictionaryKeyDeletionRanges;
 
 @interface NSString (Morphing)
 

--- a/Classes/NSString+Morphing.m
+++ b/Classes/NSString+Morphing.m
@@ -8,6 +8,10 @@
 
 #import "NSString+Morphing.h"
 
+NSString * const kTOMSDictionaryKeyMergedString = @"mergedString";
+NSString * const kTOMSDictionaryKeyAdditionRanges = @"additionRanges";
+NSString * const kTOMSDictionaryKeyDeletionRanges = @"deletionRanges";
+
 @implementation NSString (Morphing)
 
 - (NSUInteger)toms_unicodeLength

--- a/Classes/TOMSMorphingLabel.h
+++ b/Classes/TOMSMorphingLabel.h
@@ -12,10 +12,10 @@
 @interface TOMSMorphingLabel : UILabel
 
 @property (readonly, atomic, strong) NSString *targetText;
-@property (nonatomic, assign) CGFloat animationDuration;
-@property (nonatomic, assign) CGFloat characterAnimationOffset;
-@property (nonatomic, assign) CGFloat characterShrinkFactor;
-@property (nonatomic, assign, getter=isMorphingEnabled) BOOL morphingEnabled;
+@property (nonatomic, assign) IBInspectable CGFloat animationDuration;
+@property (nonatomic, assign) IBInspectable CGFloat characterAnimationOffset;
+@property (nonatomic, assign) IBInspectable CGFloat characterShrinkFactor;
+@property (nonatomic, assign, getter=isMorphingEnabled) IBInspectable BOOL morphingEnabled;
 
 - (void)setTextWithoutMorphing:(NSString *)text;
 - (void)setText:(NSString*)text withCompletionBlock:(void (^)(void))block;


### PR DESCRIPTION
1. It's more conventional to define external symbols for constant strings.
1. Adding `IBInspectable` to the label's properties makes it configurable from interface builder.